### PR TITLE
Remove left-pad as it was un-un-published

### DIFF
--- a/packages-list.txt
+++ b/packages-list.txt
@@ -125,7 +125,6 @@ keynames
 kik
 kik-starter
 kurdish-time
-left-pad
 less-common-words
 level-client
 level-flush


### PR DESCRIPTION
left-pad 0.0.3 was un-un-published: https://twitter.com/seldo/status/712414400808755200
